### PR TITLE
Fix Error importing numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/jneilliii/OctoPrint-BedReady"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["opencv-python-headless~=4.6.0.66"]
+plugin_requires = ["opencv-python-headless~=4.8.1.78"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
Hey i'm new in Octoprint and try to use your Plugin but always i face into errors in the Logs:

`octoprint.plugins.bedready - INFO - Error importing numpy: you should not try to import numpy from its source directory; please exit the numpy source tree, and relaunch your python interpreter from there.`

This error is bug from the opencv-python plugin and its fixed in the newest version.

I think its easier for new users if you directly add in your setup.